### PR TITLE
Increased cell padding in the table component desktop variant

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.0.4
+version: 1.0.5
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/assets/scss/global/components/_table.scss
+++ b/assets/scss/global/components/_table.scss
@@ -367,7 +367,7 @@ $Table-border-color: $color--gray-15;
 
 .Table--desktop td,
 .Table--desktop th {
- padding: 0.615em;
+  padding: 0.75em;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",


### PR DESCRIPTION
The original padding (0.615em) was a little too cramped. This release increases the table cell padding to 0.75em, giving the content more breathing-space.