### PR TITLE
Remove 100% height from body element to prevent the body from being the height of the viewport

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.1.3
+version: 1.1.4
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ port: 8001
 baseurl: "/origin"
 
 # Because we use pages rather than posts for our content, we have to list those
-# categories here to be able to list pages by category 
+# categories here to be able to list pages by category
 categories: [guidance, utilities, components, layout]
 
 # Markdown processors
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.1.2
+version: 1.1.3
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/assets/scss/local/base/_base.scss
+++ b/assets/scss/local/base/_base.scss
@@ -27,7 +27,6 @@ html {
  */
 
 body {
-  height: 100%;
   margin: 0;
   min-height: 100%;
   padding: 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",


### PR DESCRIPTION
Currently the base styles (`_base.scss`) set the `<body>` to `height: 100%`. This causes issues when there is a background set on `<html>` as the `<body>` background no longer covers the entire page and instead acts like any other element ([a better explaination](https://css-tricks.com/just-one-of-those-weird-things-about-css-background-on-body/)). 

When a background is applied to `<html>` _and_ `<body>` (as we do on some landing pages on the website to extend the footer), the body background will only apply to the height of the current viewport as seen here: 

![issue-1](https://cloud.githubusercontent.com/assets/9337078/12294177/37bb4ef0-b9f0-11e5-9d70-856db8128bbb.png)

![issue-2](https://cloud.githubusercontent.com/assets/9337078/12294179/3d1f8442-b9f0-11e5-9e31-df1f721f5f4d.png)

The issue can also be seen on a page without a background applied to `<html>` by inspecting `<body>` in the inspector. 

![issue-3](https://cloud.githubusercontent.com/assets/9337078/12294261/cc1e2018-b9f0-11e5-80ad-df4060e0dde9.png)

Removing the set height solves this issue. The remaining `min-height: 100%` gets the job done. :+1: 
