### PR TITLE
Fix SCSS syntax warnings

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -148,8 +148,6 @@ linters:
 
   SelectorFormat:
     enabled: true
-    #class_convention: '^[A-Z][a-z]+([A-Z][a-z]+)*(-{1,2}|\s|\.)*([a-z]+[A-Z]?-{0,2})*$|^(is|has)\-([a-z]+[A-Z]?-{0,2})*$'
-    #class_convention: ''
     class_convention_explanation: 'should either be written in UpperCamelCase, or begin with `is-`, `has-`, `u-`, or `l-`'
     ignored_types: element
     class_convention: |
@@ -159,7 +157,7 @@ linters:
       (-{1,2}|\.|\s){0,1}                       # followed by one or two dashes, or a dot, or a single space
       ([a-z]+[A-Z]?-{0,2})*                     # then any number of camelCase strings separated by one or two dashes.
       $|
-      ^(is|has|u|l)\-([a-zA-Z]+-{0,2})*$          # Alternatively, we start with state classes like `is`, `has`, `u`, or `l`,
+      ^(is|has|u|l)\-([a-zA-Z]+-{0,2})*$        # Alternatively, we start with state classes like `is`, `has`, `u`, or `l`,
                                                 # followed by any number of camelCase strings separated by one or two dashes.
 
   Shorthand:

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.1.5
+version: 1.1.6
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/assets/scss/global/components/_block-grid.scss
+++ b/assets/scss/global/components/_block-grid.scss
@@ -79,7 +79,7 @@ $block-grid-media-queries: true !default;
     @if $align-block-grid-to-grid {
       margin: 0;
     } @else {
-      margin: 0 (-$spacing/2);
+      margin: 0 (-$spacing / 2);
     }
     @include floatContainer;
 
@@ -89,23 +89,30 @@ $block-grid-media-queries: true !default;
       height: auto;
       width: 100%;
       @if $include-spacing {
-        padding: 0 ($spacing/2) $spacing;
+        padding: 0 ($spacing / 2) $spacing;
       }
     }
   }
 
   @if $per-row {
     > .#{$block-grid-element-class} {
-      @if $include-spacing {
-        padding: 0 ($spacing/2) $spacing;
-      }
-      width: 100%/$per-row;
+        width: 100% / $per-row;
 
-      &:nth-of-type(1n) { clear: none; }
-      &:nth-of-type(#{$per-row}n+1) { clear: both; }
-      @if $align-block-grid-to-grid {
-        @include block-grid-aligned($per-row, $spacing);
+      @if $include-spacing {
+        padding: 0 ($spacing / 2) $spacing;
       }
+    }
+
+    > .#{$block-grid-element-class}:nth-of-type(1n) {
+        clear: none;
+      }
+
+    > .#{$block-grid-element-class}:nth-of-type(#{$per-row}n+1) {
+        clear: both;
+      }
+
+    @if $align-block-grid-to-grid {
+      @include block-grid-aligned($per-row, $spacing);
     }
   }
 }
@@ -117,6 +124,7 @@ $block-grid-media-queries: true !default;
       @if $per-row == $i {
         $grid-column: '';
       }
+
       &:nth-of-type(#{$per-row}n#{unquote($grid-column)}) {
         padding-left: ($spacing - (($spacing / $per-row) * ($per-row - ($i - 1))));
         padding-right: ($spacing - (($spacing / $per-row) * $i));

--- a/assets/scss/global/components/_grid.scss
+++ b/assets/scss/global/components/_grid.scss
@@ -34,7 +34,7 @@
 
 @function convert-to-rem($value, $base-value: $rem-base) {
   $value: strip-unit($value) / strip-unit($base-value) * 1rem;
-  @if ($value == 0rem) { $value: 0; } // Turn 0rem into 0
+  @if ($value == 0) { $value: 0; } // Turn 0rem into 0
   @return $value;
 }
 
@@ -115,10 +115,10 @@ $include-xl-html-grid-classes: false !default;
 
 
 @mixin clearRow {
-  &:after {
+  &::after {
+    clear: both;
     content: "";
     display: table;
-    clear: both;
   }
 }
 
@@ -147,27 +147,21 @@ $include-xl-html-grid-classes: false !default;
 
   // use `@include grid-row(nest);` to include a nested row
   @if $behavior == nest {
-    margin: 0 (-($column-gutter/2));
+    margin: 0 (-($column-gutter / 2));
     max-width: none;
     width: auto;
-  }
-
-  // use `@include grid-row(collapse);` to collapsed a container row margins
-  @else if $behavior == collapse {
+  } @else if $behavior == collapse {
+    // use `@include grid-row(collapse);` to collapsed a container row margins
     margin: 0;
     max-width: $row-width;
     width: 100%;
-  }
-
-  // use @include grid-row(nest-collapse); to collapse outer margins on a nested row
-  @else if $behavior == nest-collapse {
+  } @else if $behavior == nest-collapse {
+    // use @include grid-row(nest-collapse); to collapse outer margins on a nested row
     margin: 0;
     max-width: none;
     width: auto;
-  }
-
-  // use @include grid-row; to use a container row
-  @else {
+  } @else {
+    // use @include grid-row; to use a container row
     margin: 0 auto;
     max-width: $row-width;
     width: 100%;
@@ -211,11 +205,9 @@ $include-xl-html-grid-classes: false !default;
   @if $collapse {
     padding-left: 0;
     padding-right: 0;
-  }
-
-  // Gutter padding whenever a column isn't set to collapse
-  // (use $collapse:null to do nothing)
-  @else if $collapse == false {
+  } @else if $collapse == false {
+    // Gutter padding whenever a column isn't set to collapse
+    // (use $collapse:null to do nothing)
     padding-left: ($column-gutter / 2);
     padding-right: ($column-gutter / 2);
   }
@@ -225,17 +217,30 @@ $include-xl-html-grid-classes: false !default;
     width: grid-calc($columns, $total-columns);
 
     // If last column, float naturally instead of to the right
-    @if $last-column { float: $opposite-direction; }
+    @if $last-column {
+      float: $opposite-direction;
+    }
   }
 
   // Source Ordering, adds left/right depending on which you use.
-  @if $push { #{$default-float}: grid-calc($push, $total-columns); #{$opposite-direction}: auto; }
-  @if $pull { #{$opposite-direction}: grid-calc($pull, $total-columns); #{$default-float}: auto; }
+  @if $push {
+    #{$default-float}: grid-calc($push, $total-columns);
+    #{$opposite-direction}: auto;
+  }
+
+  @if $pull {
+    #{$opposite-direction}: grid-calc($pull, $total-columns);
+    #{$default-float}: auto;
+  }
 
   @if $float {
-    @if $float == left or $float == true { float: $default-float; }
-    @else if $float == right { float: $opposite-direction; }
-    @else { float: none; }
+    @if $float == left or $float == true {
+      float: $default-float;
+    } @else if $float == right {
+      float: $opposite-direction;
+    } @else {
+      float: none;
+    }
   }
 
   // If centered, get rid of float and add appropriate margins
@@ -246,7 +251,9 @@ $include-xl-html-grid-classes: false !default;
   }
 
   // If offset, calculate appropriate margins
-  @if $offset { margin-#{$default-float}: grid-calc($offset, $total-columns) !important; }
+  @if $offset {
+    margin-#{$default-float}: grid-calc($offset, $total-columns) !important;
+  }
 
 }
 
@@ -263,6 +270,7 @@ $include-xl-html-grid-classes: false !default;
     .#{$grid-column-class}.#{$size}-push-#{$i} {
       @include grid-column($push:$i, $collapse:null, $float:false);
     }
+
     .#{$grid-column-class}.#{$size}-pull-#{$i} {
       @include grid-column($pull:$i, $collapse:null, $float:false);
     }
@@ -309,39 +317,56 @@ $include-xl-html-grid-classes: false !default;
     float: $opposite-direction;
   }
 
-  .#{$grid-row-class} {
-    &.#{$size}-collapse {
-      > .#{$grid-column-class} { @include grid-column($collapse:true, $float:false); }
-
-      .#{$grid-row-class} {margin-left:0; margin-right:0;}
-    }
-    &.#{$size}-uncollapse {
-      > .#{$grid-column-class} {
-        @include grid-column;
-      }
-    }
+  .#{$grid-row-class}.#{$size}-collapse > .#{$grid-column-class} {
+    @include grid-column($collapse:true, $float:false);
   }
+
+  .#{$grid-row-class}.#{$size}-collapse .#{$grid-row-class} {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .#{$grid-row-class}.#{$size}-uncollapse > .#{$grid-column-class} {
+    @include grid-column;
+  }
+
 }
 
+
 @if $include-html-grid-classes {
+
   .#{$grid-row-class} {
     @include grid-row;
-
-    &.collapse {
-      > .#{$grid-column-class} { @include grid-column($collapse:true, $float:false); }
-
-      .#{$grid-row-class} {margin-left:0; margin-right:0;}
-    }
-
-    .#{$grid-row-class} { @include grid-row($behavior:nest);
-      &.collapse { @include grid-row($behavior:nest-collapse); }
-    }
   }
 
-  .#{$grid-column-class} { @include grid-column($columns:$total-columns); }
+  .#{$grid-row-class}.collapse > .#{$grid-column-class} {
+    @include grid-column($collapse:true, $float:false);
+  }
 
-  .#{$grid-column-class} + .#{$grid-column-class}:last-child { float: $last-child-float; }
-  .#{$grid-column-class} + .#{$grid-column-class}.end { float: $default-float; }
+  .#{$grid-row-class}.collapse .#{$grid-row-class} {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .#{$grid-row-class} .#{$grid-row-class} {
+    @include grid-row($behavior:nest);
+  }
+
+  .#{$grid-row-class} .#{$grid-row-class}.collapse {
+    @include grid-row($behavior:nest-collapse);
+  }
+
+  .#{$grid-column-class} {
+    @include grid-column($columns:$total-columns);
+  }
+
+  .#{$grid-column-class} + .#{$grid-column-class}:last-child {
+    float: $last-child-float;
+  }
+
+  .#{$grid-column-class} + .#{$grid-column-class}.end {
+    float: $default-float;
+  }
 
   @media #{$small-up} {
     @include grid-html-classes($size:sm);
@@ -354,6 +379,7 @@ $include-xl-html-grid-classes: false !default;
       .push-#{$i} {
         @include grid-column($push:$i, $collapse:null, $float:false);
       }
+
       .pull-#{$i} {
         @include grid-column($pull:$i, $collapse:null, $float:false);
       }
@@ -366,6 +392,7 @@ $include-xl-html-grid-classes: false !default;
       .push-#{$i} {
         @include grid-column($push:$i, $collapse:null, $float:false);
       }
+
       .pull-#{$i} {
         @include grid-column($pull:$i, $collapse:null, $float:false);
       }
@@ -378,6 +405,7 @@ $include-xl-html-grid-classes: false !default;
       .push-#{$i} {
         @include grid-column($push:$i, $collapse:null, $float:false);
       }
+
       .pull-#{$i} {
         @include grid-column($pull:$i, $collapse:null, $float:false);
       }
@@ -390,6 +418,7 @@ $include-xl-html-grid-classes: false !default;
       .push-#{$i} {
         @include grid-column($push:$i, $collapse:null, $float:false);
       }
+
       .pull-#{$i} {
         @include grid-column($pull:$i, $collapse:null, $float:false);
       }
@@ -402,6 +431,7 @@ $include-xl-html-grid-classes: false !default;
   @media #{$xlarge-up} {
     @include grid-html-classes($size:xlarge);
   }
+
   @media #{$xxlarge-up} {
     @include grid-html-classes($size:xxlarge);
   }

--- a/assets/scss/global/components/_heading.scss
+++ b/assets/scss/global/components/_heading.scss
@@ -155,23 +155,23 @@ $Heading-spacing: 0;
  */
 
 .Heading--space--xx-small {
-  margin-bottom: 0.15em;
+  margin-bottom: .15em;
 }
 
 .Heading--space--x-small {
-  margin-bottom: 0.25em;
+  margin-bottom: .25em;
 }
 
 .Heading--space--small {
-  margin-bottom: 0.35em;
+  margin-bottom: .35em;
 }
 
 .Heading--space--default {
-  margin-bottom: 0.5em;
+  margin-bottom: .5em;
 }
 
 .Heading--space--large {
-  margin-bottom: 0.75em;
+  margin-bottom: .75em;
 }
 
 
@@ -206,14 +206,6 @@ $Heading-spacing: 0;
   @include font-weight(bold);
 }
 
-.Heading--weight--x-bold {
-  @include font-weight(x-bold);
-}
-
-.Heading--weight--black {
-  @include font-weight(black);
-}
-
 
 /* Editorial modifications
   ========================================================================== */
@@ -224,7 +216,7 @@ $Heading-spacing: 0;
 .l-editorial h4,
 .l-editorial h5,
 .l-editorial h6 {
-  margin-bottom: 0.25em;
+  margin-bottom: .25em;
 }
 
 .l-editorial h2 {
@@ -236,13 +228,13 @@ $Heading-spacing: 0;
 }
 
 .l-editorial h4 {
-  margin-top: 0.5em;
+  margin-top: .5em;
 }
 
 .l-editorial h5 {
-  margin-top: 0.5em;
+  margin-top: .5em;
 }
 
 .l-editorial h6 {
-  margin-top: 0.5em;
+  margin-top: .5em;
 }

--- a/assets/scss/global/components/_list.scss
+++ b/assets/scss/global/components/_list.scss
@@ -1,29 +1,25 @@
 /* List component
    ========================================================================== */
 
+/**
+ * Mixins
+ */
+
+@mixin List--dashed--list-item-before {
+  @include text-color(gray-11);
+  content: "—";
+  margin-left: -1.15em;
+  margin-right: .15em;
+}
+
 .List {
   @include padding(0 0 0 small);
   margin: 0;
 }
 
-.List li {
-  margin-bottom: 0.25em;
-}
-
-.List--tight li {
-  margin-bottom: 0.15em;
-}
-
-.List--loose li {
-  margin-bottom: 0.5em;
-}
-
-.List--x-loose li {
-  margin-bottom: 0.75em;
-}
-
-.List--xx-loose li {
-  margin-bottom: 1em;
+.List--bare {
+  list-style: none;
+  padding-left: 0;
 }
 
 .List--dashed {
@@ -40,9 +36,17 @@
   padding-left: 0;
 }
 
+.List li {
+  margin-bottom: .25em;
+}
+
 .List--dashed li {
-  list-style: none;
   @include list-item-spacing(loose);
+  list-style: none;
+}
+
+.List--dashed li::before {
+  @include List--dashed--list-item-before;
 }
 
 .List--dashed--loose li {
@@ -53,42 +57,23 @@
   @include list-item-spacing(xx-loose);
 }
 
-@mixin List--dashed--list-item-before {
-  content: "—";
-  margin-left: -1.15em;
-  margin-right: 0.15em;
-  @include text-color(gray-11);
+.List--loose li {
+  margin-bottom: .5em;
 }
 
-.List--dashed li:before {
-  @include List--dashed--list-item-before;
+.List--tight li {
+  margin-bottom: .15em;
 }
 
-.List--bare {
-  list-style: none;
-  padding-left: 0;
+.List--x-loose li {
+  margin-bottom: .75em;
 }
 
-.List-item--margin--0 li {
-  margin-bottom: 0;
+.List--xx-loose li {
+  margin-bottom: 1em;
 }
 
-.List--features {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.List--features .List-item {
-  @include margin-bottom(large);
-}
-
-.List--features .List-item .Heading {
-  margin-top: 0;
-  @include margin-bottom(xx-small);
-}
-
-.List--features .List-item .Metadata--excerpt-text {
+.List--x-tight li {
   margin-bottom: 0;
 }
 
@@ -99,14 +84,14 @@
 }
 
 .List--orderedCounter-count::before {
+  @include text-color(x-light);
   content: counter(List--orderedCounter);
-	counter-increment: List--orderedCounter;
+  counter-increment: List--orderedCounter;
   display: inline-block;
   margin-left: -1.75em;
-  margin-right: 0.25em;
+  margin-right: .25em;
   text-align: right;
   width: 1.25em;
-  @include text-color(x-light);
 }
 
 .List--weight--semi-bold {

--- a/assets/scss/global/components/_table.scss
+++ b/assets/scss/global/components/_table.scss
@@ -45,7 +45,7 @@ $Table-border-color: $color--gray-15;
   /* 2 */
   border-spacing: 0;
   /* 3 */
-  margin: 0 0 1em 0;
+  margin: 0 0 1em;
   padding: 0;
   text-align: left;
   /* 4 */
@@ -65,7 +65,7 @@ $Table-border-color: $color--gray-15;
 .Table td,
 .Table th {
   margin: 0;
-  padding: 0.5em;
+  padding: .5em;
   /* 1 */
   vertical-align: middle;
 }
@@ -125,7 +125,7 @@ tbody tr:first-child td {
 .Table-header--prominent {
   @include background-color(gray-16);
   /* 1 */
-  border-top: 1px solid white;
+  border-top: 1px solid #fff;
 }
 
 /**
@@ -133,7 +133,7 @@ tbody tr:first-child td {
  * table header.
  *
  * 1. This header is designed to group together the cell columns of the row
- *    underneath it, so we centre align the text as the best way of doing so. 
+ *    underneath it, so we centre align the text as the best way of doing so.
  */
 
 .Table .Table-row--parentHeader th {
@@ -368,7 +368,7 @@ tbody tr:first-child td {
 .Table-row--verticalBorders--white td,
 .Table-row--verticalBorders--white th,
 .Table-cell--verticalBorders--white {
-  border-color: white;
+  border-color: #fff;
 }
 
 /**
@@ -376,7 +376,7 @@ tbody tr:first-child td {
  */
 
 .Table-cell--verticalBorder--white--left {
-  border-left: 1px solid white;
+  border-left: 1px solid #fff;
 }
 
 /**
@@ -384,7 +384,7 @@ tbody tr:first-child td {
  */
 
 .Table-cell--verticalBorder--white--right {
-  border-right: 1px solid white;
+  border-right: 1px solid #fff;
 }
 
 /**
@@ -399,22 +399,6 @@ tbody tr:first-child td {
   border-color: desaturate(lighten($color--fa-blue, 45), 50);
 }
 
-/**
- * Add a left-hand border to a cell inside a <thead>.
- */
-
-.Table-cell--verticalBorder--white--left {
-  border-left: 1px solid white;
-}
-
-/**
- * Add a right-hand border to a cell inside a <thead>.
- */
-
-.Table-cell--verticalBorder--white--right {
-  border-right: 1px solid white;
-}
-
 /* `Table--zebraStripes` variant
    ==========================================================================
    Note that when applied to a whole table, zebra stripes are scoped only to
@@ -423,7 +407,7 @@ tbody tr:first-child td {
 
 .Table--zebraStripes tbody tr:nth-child(even),
 .Table-row--zebraStripes:nth-child(even) {
-  background-color: rgba(200, 200, 200, 0.14);
+  background-color: rgba(200, 200, 200, .14);
 }
 
 /**
@@ -464,7 +448,7 @@ tbody tr:first-child td {
 
 .Table--desktop td,
 .Table--desktop th {
-  padding: 0.75em;
+  padding: .75em;
 }
 
 .Table--desktop th {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",


### PR DESCRIPTION
This fixes all newly introduced SCSS syntax warnings over the last few releases.

It leaves only the `suspended` class issue remaining, which has always existed since the introduction of the Table component. This class exists only to support table behaviour in the desktop app, and will be renamed once the required JS work has been completed on desktop.