### PR TITLE
WIP: Updated heading component with `underline` variants.

### DIFF
--- a/assets/scss/global/components/_heading.scss
+++ b/assets/scss/global/components/_heading.scss
@@ -178,15 +178,15 @@ $Heading-spacing: 0;
 /* Underlines
   ========================================================================== */
 
-.Heading--underline {
+.Heading--underlined {
   @include border-bottom(default, gray-12);
 }
 
-.Heading--underline--dark {
+.Heading--underlined--dark {
   @include border-bottom(default, gray-8)
 }
 
-.Heading--underline--light {
+.Heading--underlined--light {
   @include border-bottom(default, gray-14);
 }
 

--- a/assets/scss/global/components/_heading.scss
+++ b/assets/scss/global/components/_heading.scss
@@ -175,6 +175,22 @@ $Heading-spacing: 0;
 }
 
 
+/* Underlines
+  ========================================================================== */
+
+.Heading--underline {
+  @include border-bottom(default, gray-12);
+}
+
+.Heading--underline--dark {
+  @include border-bottom(default, gray-8)
+}
+
+.Heading--underline--light {
+  @include border-bottom(default, gray-14);
+}
+
+
 /* Weights
   ========================================================================== */
 

--- a/docs/components/heading.md
+++ b/docs/components/heading.md
@@ -282,20 +282,21 @@ The Heading component doesn't have any margin by default, so it's very flexible.
 
 
 ## Underlines
+When further distinction is required between a heading and the content below and underline can be applied. An example of this would be the [glossary index listings](http://www.freeagent.com/glossary).
 {% example html %}
-<h2 class="Heading Heading--weight--bold Heading--underline">
+<h2 class="Heading Heading--weight--bold Heading--underlined">
   Heading With Underline
 </h2>
 {% endexample %}
 
 {% example html %}
-<h2 class="Heading Heading-weight--bold Heading--underline--light">
+<h2 class="Heading Heading-weight--bold Heading--underlined--light">
   Heading With Light Underline
 </h2>
 {% endexample %}
 
 {% example html %}
-<h2 class="Heading Heading--weight--bold Heading--underline--dark">
+<h2 class="Heading Heading--weight--bold Heading--underlined--dark">
   Heading With Dark Underline;
 </h2>
 {% endexample %}

--- a/docs/components/heading.md
+++ b/docs/components/heading.md
@@ -281,6 +281,26 @@ The Heading component doesn't have any margin by default, so it's very flexible.
 {% endexample %}
 
 
+## Underlines
+{% example html %}
+<h2 class="Heading Heading--weight--bold Heading--underline">
+  Heading With Underline
+</h2>
+{% endexample %}
+
+{% example html %}
+<h2 class="Heading Heading-weight--bold Heading--underline--light">
+  Heading With Light Underline
+</h2>
+{% endexample %}
+
+{% example html %}
+<h2 class="Heading Heading--weight--bold Heading--underline--dark">
+  Heading With Dark Underline;
+</h2>
+{% endexample %}
+
+
 ## Weights
 {% example html %}
 <h2 class="Heading Heading--weight--light Heading--x-large">


### PR DESCRIPTION
Adds an underline variant to the `Heading` component using `Heading--underline`.
<img width="774" alt="screen shot 2016-01-28 at 11 16 01" src="https://cloud.githubusercontent.com/assets/4366929/12642955/ea0ef6ee-c5b0-11e5-82fc-f5a0174bcbb6.png">
