### PR TITLE
Fix IE8 support for fonts in _source_sans-pro.scss

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.1.7
+version: 1.1.8
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/assets/scss/global/fonts/_source-sans-pro.scss
+++ b/assets/scss/global/fonts/_source-sans-pro.scss
@@ -19,7 +19,7 @@
   font-style: normal;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-ExtraLight.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-ExtraLight.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-ExtraLight.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-ExtraLight.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-ExtraLight.ttf.woff') format('woff'),
@@ -36,7 +36,7 @@
   font-style: italic;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-ExtraLightIt.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-ExtraLightIt.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-ExtraLightIt.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-ExtraLightIt.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-ExtraLightIt.ttf.woff') format('woff'),
@@ -53,7 +53,7 @@
   font-style: normal;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Light.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Light.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-Light.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-Light.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-Light.ttf.woff') format('woff'),
@@ -70,7 +70,7 @@
   font-style: italic;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-LightIt.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-LightIt.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-LightIt.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-LightIt.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-LightIt.ttf.woff') format('woff'),
@@ -87,7 +87,7 @@
   font-style: normal;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Regular.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Regular.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-Regular.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-Regular.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-Regular.ttf.woff') format('woff'),
@@ -104,7 +104,7 @@
   font-style: italic;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-It.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-It.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-It.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-It.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-It.ttf.woff') format('woff'),
@@ -121,7 +121,7 @@
   font-style: normal;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Semibold.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Semibold.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-Semibold.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-Semibold.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-Semibold.ttf.woff') format('woff'),
@@ -138,7 +138,7 @@
   font-style: italic;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-SemiboldIt.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-SemiboldIt.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-SemiboldIt.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-SemiboldIt.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-SemiboldIt.ttf.woff') format('woff'),
@@ -155,7 +155,7 @@
   font-style: normal;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Bold.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Bold.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-Bold.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-Bold.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-Bold.ttf.woff') format('woff'),
@@ -172,7 +172,7 @@
   font-style: italic;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-BoldIt.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-BoldIt.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-BoldIt.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-BoldIt.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-BoldIt.ttf.woff') format('woff'),
@@ -189,7 +189,7 @@
   font-style: normal;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Black.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-Black.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-Black.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-Black.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-Black.ttf.woff') format('woff'),
@@ -206,7 +206,7 @@
   font-style: italic;
   font-stretch: normal;
   src: supported-font-sources((
-    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-BlackIt.eot') format('embedded-opentype'),
+    embedded-opentype: url('#{$font-path}/SourceSansPro/EOT/SourceSansPro-BlackIt.eot?#iefix') format('embedded-opentype'),
     truetype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/TTF/SourceSansPro-BlackIt.ttf.woff2') format('woff2'),
     opentype-woff2:    url('#{$font-path}/SourceSansPro/WOFF2/OTF/SourceSansPro-BlackIt.otf.woff2') format('woff2'),
     truetype-woff:     url('#{$font-path}/SourceSansPro/WOFF/TTF/SourceSansPro-BlackIt.ttf.woff') format('woff'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",


### PR DESCRIPTION
Previously Source Sans Pro wasn't loading in IE8, due to a little [quirk](http://stackoverflow.com/questions/8050640/how-does-iefix-solve-web-fonts-loading-in-ie6-ie8) in IE8 where if there are multiple font sources in one font-face rule, IE8 won't load any of them. 

This fixes it by using a query string to trick IE into thinking the other font paths are part of that query string and they're all really just one font. Smart! 

And now Source Sans loads in IE8. :tada: 

![screen shot 2016-02-02 at 10 52 32](https://cloud.githubusercontent.com/assets/9337078/12747301/1f6b4c50-c99b-11e5-8f9d-ef42a1b41cbe.png)
