### PR TITLE
Scope table row border rule to only apply inside a .Table component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
-    activesupport (4.2.5.1)
+    activesupport (4.2.5.2)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.2.1
+version: 1.2.2
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/assets/scss/global/components/_table.scss
+++ b/assets/scss/global/components/_table.scss
@@ -84,7 +84,7 @@ $Table-border-color: $color--gray-15;
  * coloured light blue.
  */
 
-tbody tr:first-child td {
+.Table tbody tr:first-child td {
   border-top: 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",


### PR DESCRIPTION
Corrects an issue with a rule (`tbody tr:first-child td`) in the .Table component which wasn't scoped tightly enough.