### PR TITLE
Heading with zero margin bottom

### DIFF
--- a/assets/scss/global/components/_heading.scss
+++ b/assets/scss/global/components/_heading.scss
@@ -40,7 +40,6 @@ $Heading-spacing: 0;
   margin-left: 0;
   margin-right: 0;
   margin-top: 0;
-  margin-bottom: map-get($spacing-values, $Heading-spacing) $important;
 }
 
 

--- a/docs/components/heading.md
+++ b/docs/components/heading.md
@@ -331,7 +331,7 @@ When further distinction is required between a heading and the content below and
 
 
 ## Editorial spacing
-By default, the `Heading` component has no margins other than a small `margin-bottom`. Being so unopinionated means it can be used in a multitude of contexts without alteration.
+By default, the `Heading` component has no margins. Being so unopinionated means it can be used in a multitude of contexts without alteration.
 
 But when we're writing editorial content like articles and blog posts, we want headings to be spaced sympathetically. Spacing that improves the reading experience, but also doesn't require us to add classes to every single heading. By wrapping editorial content in a `l-editorial` container, that's what we get.
 


### PR DESCRIPTION
In the current release of Origin there is a slight margin-bottom applied to every heading component. This PR removes this in favour of keeping the component as simple as possible without having to add any additional CSS to remove its default behaviour (as was happening with the [card component](https://github.com/fac/origin/pull/22#discussion_r58889185)). 