### PR TITLE
Pin development gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,10 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+require "json"
+require "open-uri"
 
-gem 'github-pages', versions['github-pages']
+gem "github-pages", "82"
 
-gem 'jekyll'
-gem 'rouge'
-gem 'sass'
+gem "jekyll", "3.1.6"
+gem "rouge", "1.10.1"
+gem "sass",  "3.4.22"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,10 +121,10 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages (= 82)
-  jekyll
+  jekyll (= 3.1.6)
   json
-  rouge
-  sass
+  rouge (= 1.10.1)
+  sass (= 3.4.22)
 
 BUNDLED WITH
    1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.2.9
+version: 1.2.10
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.2.10
+version: 1.2.11
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.2.11
+version: 1.2.12
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",


### PR DESCRIPTION
*Story*
As a designer I do not want to have to resolve development dependencies every time I release origin due to github releasing a new version of github pages so I can have a stress free release.

*Details*

* Pin the development gems to specific versions.
* Replace single quotes with double
* Bump version number 1.2.10 to 1.2.11
.