### PR TITLE
Added utility classes for `lower-alpha` and `upper-alpha` list types.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ highlighter: rouge
 kramdown:
   auto_ids: true
 
-version: 1.2.12
+version: 1.2.13
 
 sass:
   # Directory points to root allowing `@import` of .scss files from anywhere

--- a/assets/scss/global/utilities/_utility-values.scss
+++ b/assets/scss/global/utilities/_utility-values.scss
@@ -698,7 +698,13 @@ $list-style-values:
   (disc, disc)
   (disc-inside, disc inside)
   (disc-outside, disc outside)
-  (none, none);
+  (lower-alpha, lower-alpha)
+  (lower-alpha-inside, lower-alpha inside)
+  (lower-alpha-outside, lower-alpha outside)
+  (none, none)
+  (upper-alpha, upper-alpha)
+  (upper-alpha-inside, upper-alpha inside)
+  (upper-alpha-outside, upper-alpha outside);
 
 
 /* `opacity`

--- a/docs/utilities/list-style.md
+++ b/docs/utilities/list-style.md
@@ -13,7 +13,13 @@ Apply `list-style` values using our utility classes.
 * `disc`
 * `disc-inside`
 * `disc-outside`
+* `lower-alpha`
+* `lower-alpha-inside`
+* `lower-alpha-outside`
 * `none`
+* `upper-alpha`
+* `upper-alpha-inside`
+* `upper-alpha-outside`
 
 ### Examples
 {% example html %}
@@ -65,9 +71,57 @@ Apply `list-style` values using our utility classes.
 {% endexample %}
 
 {% example html %}
+<ul class="u-list-style--lower-alpha">
+  <li>Lower-alpha list style</li>
+  <li>Lower-alpha list style</li>
+  <li>Lower-alpha list style</li>
+</ul>
+{% endexample %}
+
+{% example html %}
+<ul class="u-list-style--lower-alpha-inside">
+  <li>Lower-alpha-inside list style</li>
+  <li>Lower-alpha-inside list style</li>
+  <li>Lower-alpha-inside list style</li>
+</ul>
+{% endexample %}
+
+{% example html %}
+<ul class="u-list-style--lower-alpha-outside">
+  <li>lower-alpha-outside list style</li>
+  <li>lower-alpha-outside list style</li>
+  <li>lower-alpha-outside list style</li>
+</ul>
+{% endexample %}
+
+{% example html %}
 <ul class="u-list-style--none">
   <li>No list style</li>
   <li>No list style</li>
   <li>No list style</li>
+</ul>
+{% endexample %}
+
+{% example html %}
+<ul class="u-list-style--upper-alpha">
+  <li>Upper-alpha list style</li>
+  <li>Upper-alpha list style</li>
+  <li>Upper-alpha list style</li>
+</ul>
+{% endexample %}
+
+{% example html %}
+<ul class="u-list-style--upper-alpha-inside">
+  <li>Upper-alpha-inside list style</li>
+  <li>Upper-alpha-inside list style</li>
+  <li>Upper-alpha-inside list style</li>
+</ul>
+{% endexample %}
+
+{% example html %}
+<ul class="u-list-style--upper-alpha-outside">
+  <li>Upper-alpha-outside list style</li>
+  <li>Upper-alpha-outside list style</li>
+  <li>Upper-alpha-outside list style</li>
 </ul>
 {% endexample %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-css",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "homepage": "http://fac.github.io/origin",
   "author": "FreeAgent",
   "scss": "./assets/scss/origin.scss",


### PR DESCRIPTION
Presently within Origin we have no existing utility classes for the creation of alphabetic lists such as those often required in the break down of [terms & conditions](http://www.freeagent.com/natwest/survey/prize-draw-one/).

This pull requests updates the utility values to include all variations of both lowercase and uppercase alphabetic list types resulting in additional utility classes being made available.