### PR TITLE
Add proper IE8 fallbacks for font-size and spacing values

### DIFF
--- a/assets/scss/global/utilities/_utility-values.scss
+++ b/assets/scss/global/utilities/_utility-values.scss
@@ -754,23 +754,23 @@ $top-values:
 
 /* Values */
 $spacing--0:  0;
-$spacing--1:  .15rem;
-$spacing--2:  .25rem;
-$spacing--3:  .5rem;
-$spacing--4:  .75rem;
-$spacing--5:  1rem;
-$spacing--6:  1.25rem;
-$spacing--7:  1.5rem;
-$spacing--8:  1.75rem;
-$spacing--9:  2rem;
-$spacing--10: 2.25rem;
-$spacing--11: 2.5rem;
-$spacing--12: 2.75rem;
-$spacing--13: 3rem;
-$spacing--14: 3.5rem;
-$spacing--15: 4rem;
-$spacing--16: 4.5rem;
-$spacing--17: 5rem;
+$spacing--1:  .15;
+$spacing--2:  .25;
+$spacing--3:  .5;
+$spacing--4:  .75;
+$spacing--5:  1;
+$spacing--6:  1.25;
+$spacing--7:  1.5;
+$spacing--8:  1.75;
+$spacing--9:  2;
+$spacing--10: 2.25;
+$spacing--11: 2.5;
+$spacing--12: 2.75;
+$spacing--13: 3;
+$spacing--14: 3.5;
+$spacing--15: 4;
+$spacing--16: 4.5;
+$spacing--17: 5;
 
 /* Aliases */
 $spacing--xx-small: $spacing--1;

--- a/assets/scss/global/utilities/_utility-values.scss
+++ b/assets/scss/global/utilities/_utility-values.scss
@@ -454,29 +454,24 @@ $font-family-values: (
 /* Base typographic unit, equal to web browser default */
 $base-unit: 16;
 
-/* Function to convert `px` to `rem` */
-@function rem($pixels, $context: $base-unit) {
-  @return #{$pixels / $context}rem;
-}
-
-/* Values */
-$font-size--1:  rem(9);
-$font-size--2:  rem(10);
-$font-size--3:  rem(11);
-$font-size--4:  rem(12);
-$font-size--5:  rem(14);
-$font-size--6:  rem(16);
-$font-size--7:  rem(18);
-$font-size--8:  rem(21);
-$font-size--9:  rem(24);
-$font-size--10: rem(28);
-$font-size--11: rem(32);
-$font-size--12: rem(36);
-$font-size--13: rem(42);
-$font-size--14: rem(48);
-$font-size--15: rem(54);
-$font-size--16: rem(60);
-$font-size--17: rem(72);
+/* Values in pixels */
+$font-size--1:  9;
+$font-size--2:  10;
+$font-size--3:  11;
+$font-size--4:  12;
+$font-size--5:  14;
+$font-size--6:  16;
+$font-size--7:  18;
+$font-size--8:  21;
+$font-size--9:  24;
+$font-size--10: 28;
+$font-size--11: 32;
+$font-size--12: 36;
+$font-size--13: 42;
+$font-size--14: 48;
+$font-size--15: 54;
+$font-size--16: 60;
+$font-size--17: 72;
 
 /* Aliases */
 $font-size--xx-small: $font-size--3;
@@ -759,23 +754,23 @@ $top-values:
 
 /* Values */
 $spacing--0:  0;
-$spacing--1:  .15em;
-$spacing--2:  .25em;
-$spacing--3:  .5em;
-$spacing--4:  .75em;
-$spacing--5:  1em;
-$spacing--6:  1.25em;
-$spacing--7:  1.5em;
-$spacing--8:  1.75em;
-$spacing--9:  2em;
-$spacing--10: 2.25em;
-$spacing--11: 2.5em;
-$spacing--12: 2.75em;
-$spacing--13: 3em;
-$spacing--14: 3.5em;
-$spacing--15: 4em;
-$spacing--16: 4.5em;
-$spacing--17: 5em;
+$spacing--1:  .15rem;
+$spacing--2:  .25rem;
+$spacing--3:  .5rem;
+$spacing--4:  .75rem;
+$spacing--5:  1rem;
+$spacing--6:  1.25rem;
+$spacing--7:  1.5rem;
+$spacing--8:  1.75rem;
+$spacing--9:  2rem;
+$spacing--10: 2.25rem;
+$spacing--11: 2.5rem;
+$spacing--12: 2.75rem;
+$spacing--13: 3rem;
+$spacing--14: 3.5rem;
+$spacing--15: 4rem;
+$spacing--16: 4.5rem;
+$spacing--17: 5rem;
 
 /* Aliases */
 $spacing--xx-small: $spacing--1;

--- a/assets/scss/global/utilities/utilities/_font-size.scss
+++ b/assets/scss/global/utilities/utilities/_font-size.scss
@@ -9,9 +9,15 @@
  * https://github.com/fac/origin/tree/master/assets/scss/global/utilities/_utility-values.scss
  */
 
+/* Function to convert `px` to `rem` */
+@function rem($pixels, $context: $base-unit) {
+  @return #{$pixels / $context}rem;
+}
+
 
 @mixin font-size($value, $important: null) {
-  font-size: map-get($font-size-values, $value) $important;
+  font-size: map-get($font-size-values, $value)px $important;
+  font-size: rem(map-get($font-size-values, $value)) $important;
 }
 
 
@@ -31,7 +37,8 @@
      */
 
     .u-font-size--#{$font-size} {
-      font-size: $standard-scale-font-size-value !important;
+      font-size: $standard-scale-font-size-value + px !important;
+      font-size: rem($standard-scale-font-size-value) !important;
     }
 
     @each $breakpoint-size, $breakpoint-value in $breakpoint-values {

--- a/assets/scss/global/utilities/utilities/_margin.scss
+++ b/assets/scss/global/utilities/utilities/_margin.scss
@@ -9,31 +9,44 @@
  * https://github.com/fac/origin/tree/master/assets/scss/global/utilities/_utility-values.scss
  */
 
+/* Function to convert rem to px */
+@function px($rems, $context: $base-unit) {
+  @return #{$rems * $context};
+}
+
 @mixin margin($values, $important: null) {
-  $valueList: ();
+  $pxValueList: ();
+  $remValueList: ();
 
   @for $i from 1 through length($values) {
-    $value: map-get($spacing-values, nth($values, $i));
-    $valueList: append($valueList, $value, space);
+    $pxValue: px(map-get($spacing-values, nth($values, $i))) + px;
+    $pxValueList: append($pxValueList, $pxValue, space);
+    $remValue: map-get($spacing-values, nth($values, $i)) + rem;
+    $remValueList: append($remValueList, $remValue, space);
   }
 
-  margin: $valueList $important;
+  margin: $pxValueList $important;
+  margin: $remValueList $important;
 }
 
 @mixin margin-bottom($value, $important: null) {
-  margin-bottom: map-get($spacing-values, $value) $important;
+  margin-bottom: px(map-get($spacing-values, $value)) + px $important;
+  margin-bottom: map-get($spacing-values, $value) + rem $important;
 }
 
 @mixin margin-left($value, $important: null) {
-  margin-left: map-get($spacing-values, $value) $important;
+  margin-left: px(map-get($spacing-values, $value)) + px $important;
+  margin-left: map-get($spacing-values, $value) + rem $important;
 }
 
 @mixin margin-right($value, $important: null) {
-  margin-right: map-get($spacing-values, $value) $important;
+  margin-right: px(map-get($spacing-values, $value)) + px $important;
+  margin-right: map-get($spacing-values, $value) + rem $important;
 }
 
 @mixin margin-top($value, $important: null) {
-  margin-top: map-get($spacing-values, $value) $important;
+  margin-top: px(map-get($spacing-values, $value)) + px $important;
+  margin-top: map-get($spacing-values, $value) + rem $important;
 }
 
 
@@ -53,29 +66,37 @@
      */
 
     .u-margin--#{$spacing-size} {
-      margin: $standard-scale-spacing-value !important;
+      margin: px($standard-scale-spacing-value) + px !important;
+      margin: $standard-scale-spacing-value + rem !important;
     }
 
     .u-margin-bottom--#{$spacing-size} {
-      margin-bottom: $standard-scale-spacing-value !important;
+      margin-bottom: px($standard-scale-spacing-value) + px !important;
+      margin-bottom: $standard-scale-spacing-value + rem !important;
     }
 
     .u-margin-left--#{$spacing-size} {
-      margin-left: $standard-scale-spacing-value !important;
+      margin-left: px($standard-scale-spacing-value) + px !important;
+      margin-left: $standard-scale-spacing-value + rem !important;
     }
 
     .u-margin-right--#{$spacing-size} {
-      margin-right: $standard-scale-spacing-value !important;
+      margin-right: px($standard-scale-spacing-value) + px !important;
+      margin-right: $standard-scale-spacing-value + rem !important;
     }
 
     .u-margin-top--#{$spacing-size} {
-      margin-top: $standard-scale-spacing-value !important;
+      margin-top: px($standard-scale-spacing-value) + px !important;
+      margin-top: $standard-scale-spacing-value + rem !important;
     }
 
     @each $breakpoint-size, $breakpoint-value in $breakpoint-values {
 
       /**
        * Generate standard scale of spacing classes with breakpoints
+       *
+       * These don't have IE8 fallbacks because IE8 ignores media
+       * queries anyway.
        */
 
       @include break($breakpoint-size) {

--- a/assets/scss/global/utilities/utilities/_padding.scss
+++ b/assets/scss/global/utilities/utilities/_padding.scss
@@ -3,6 +3,11 @@
    http://fac.github.io/origin/utilities/padding/
 */
 
+/* Function to convert rem to px */
+@function px($rems, $context: $base-unit) {
+  @return #{$rems * $context};
+}
+
 /**
  * This mixin allows us to use shorthand values for the `padding` property.
  *
@@ -12,30 +17,38 @@
  */
 
 @mixin padding($values, $important: null) {
-  $valueList: ();
+  $pxValueList: ();
+  $remValueList: ();
 
   @for $i from 1 through length($values) {
-    $value: map-get($spacing-values, nth($values, $i));
-    $valueList: append($valueList, $value, space);
+    $pxValue: px(map-get($spacing-values, nth($values, $i))) + px;
+    $pxValueList: append($pxValueList, $pxValue, space);
+    $remValue: map-get($spacing-values, nth($values, $i)) + rem;
+    $remValueList: append($remValueList, $remValue, space);
   }
 
-  padding: $valueList $important;
+  padding: $pxValueList $important;
+  padding: $remValueList $important;
 }
 
 @mixin padding-bottom($value, $important: null) {
-  padding-bottom: map-get($spacing-values, $value) $important;
+  padding-bottom: px(map-get($spacing-values, $value)) + px $important;
+  padding-bottom: map-get($spacing-values, $value) + rem $important;
 }
 
 @mixin padding-left($value, $important: null) {
-  padding-left: map-get($spacing-values, $value) $important;
+  padding-left: px(map-get($spacing-values, $value)) + px $important;
+  padding-left: map-get($spacing-values, $value) + rem $important;
 }
 
 @mixin padding-right($value, $important: null) {
-  padding-right: map-get($spacing-values, $value) $important;
+  padding-right: px(map-get($spacing-values, $value)) + px $important;
+  padding-right: map-get($spacing-values, $value) + rem $important;
 }
 
 @mixin padding-top($value, $important: null) {
-  padding-top: map-get($spacing-values, $value) $important;
+  padding-top: px(map-get($spacing-values, $value)) + px $important;
+  padding-top: map-get($spacing-values, $value) + rem $important;
 }
 
 
@@ -49,23 +62,28 @@
    */
 
   .u-padding {
-    padding: $spacing--default !important;
+    padding: px($spacing--default) + px !important;
+    padding: $spacing--default + rem !important;
   }
 
   .u-padding-bottom {
-    padding-bottom: $spacing--default !important;
+    padding-bottom: px($spacing--default) + px !important;
+    padding-bottom: $spacing--default + rem !important;
   }
 
   .u-padding-left {
-    padding-left: $spacing--default !important;
+    padding-left: px($spacing--default) + px !important;
+    padding-left: $spacing--default + rem !important;
   }
 
   .u-padding-right {
-    padding-right: $spacing--default !important;
+    padding-right: px($spacing--default) + px !important;
+    padding-right: $spacing--default + rem !important;
   }
 
   .u-padding-top {
-    padding-top: $spacing--default !important;
+    padding-top: px($spacing--default) + px !important;
+    padding-top: $spacing--default + rem !important;
   }
 
   @each $breakpoint-size, $breakpoint-value in $breakpoint-values {
@@ -76,6 +94,9 @@
       * Note that classes will not be generated for the full scale of spacing
       * values, only the standard `xx-small` > `xx-large` scale, because in
       * practice the full scale has never been needed.
+      *
+      * These don't have IE8 fallbacks because IE8 ignores media
+      * queries anyway.
       */
 
     @include break($breakpoint-size) {
@@ -121,29 +142,37 @@
      */
 
     .u-padding--#{$spacing-size} {
-      padding: $standard-scale-spacing-value !important;
+      padding: px($standard-scale-spacing-value) + px !important;
+      padding: $standard-scale-spacing-value + rem !important;
     }
 
     .u-padding-bottom--#{$spacing-size} {
-      padding-bottom: $standard-scale-spacing-value !important;
+      padding-bottom: px($standard-scale-spacing-value) + px !important;
+      padding-bottom: $standard-scale-spacing-value + rem !important;
     }
 
     .u-padding-left--#{$spacing-size} {
-      padding-left: $standard-scale-spacing-value !important;
+      padding-left: px($standard-scale-spacing-value) + px !important;
+      padding-left: $standard-scale-spacing-value + rem !important;
     }
 
     .u-padding-right--#{$spacing-size} {
-      padding-right: $standard-scale-spacing-value !important;
+      padding-right: px($standard-scale-spacing-value) + px !important;
+      padding-right: $standard-scale-spacing-value + rem !important;
     }
 
     .u-padding-top--#{$spacing-size} {
-      padding-top: $standard-scale-spacing-value !important;
+      padding-top: px($standard-scale-spacing-value) + px !important;
+      padding-top: $standard-scale-spacing-value + rem !important;
     }
 
     @each $breakpoint-size, $breakpoint-value in $breakpoint-values {
 
       /**
        * Generate standard scale of spacing classes with breakpoints
+       *
+       * These don't have IE8 fallbacks because IE8 ignores media
+       * queries anyway.
        */
 
       @include break($breakpoint-size) {


### PR DESCRIPTION
We're shortly going to be dropping support for IE versions 8 - 10, but in the meantime the older browsers are still slowing down implementation of the Origin utilities. This branch attempts to solve a large part of that problem by introducing pixel-value fallbacks for all font-size and spacing values. Modern browsers will still use the correct `rem` values, while IE 8 will use the equivalent pixel value.

This means we can safely employ the `font-size`, `margin` and `padding` Origin utility classes and mixins in our existing projects without worrying about them not working in older browsers or having to rely on unpredictable `em` values.

##### A few known problems with this approach
- Duplicating the attributes in the utility generators plays havoc with our linting
- When the base font size is changed, IE's pixel values will not adjust accordingly like the `rem` values

##### IE 8 issues not fixed by this branch
- Lack of `@media` query support means that the `.Grid` component and anything else reliant on breakpoints is still pretty much useless
- The Origin docs still look rubbish in IE8 because they don't use our spacing utilities, but do rely on the `.Grid` component.